### PR TITLE
SWS-250/2 Remove magic numbers/literals from deployment filtering

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -282,6 +282,13 @@ server:
 prometheus_service_url: VALUE
 ----
 
+|`SERVICE_FILTER_LABEL_NAME`
+|Label name which all resources of a service are group by. Default is `app`.
+[source,yaml]
+----
+service_filter_label_name: VALUE
+----
+
 |`GRAFANA_DISPLAY_LINK`
 |When true, a link to Grafana will be displayed for more metrics.
 [source,yaml]

--- a/config.yaml
+++ b/config.yaml
@@ -24,3 +24,7 @@ prometheus_service_url: http://prometheus-istio-system.127.0.0.1.nip.io
 # Uncomment grafana_service_url, used to generate links to Grafana
 # If unset, the Grafana service URL will be looked up from Kubernetes Grafana service. It may not always be available.
 # grafana_service_url: http://grafana-istio-system.127.0.0.1.nip.io
+
+# Uncomment service_filter_label_name to set up a different lable name for grouping all resources of a service.
+# Default is "app"
+service_filter_label_name: service

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ const (
 	EnvGrafanaDashboard        = "GRAFANA_DASHBOARD"
 	EnvGrafanaVarServiceSource = "GRAFANA_VAR_SERVICE_SOURCE"
 	EnvGrafanaVarServiceDest   = "GRAFANA_VAR_SERVICE_DEST"
+
+	EnvServiceFilterLabelName = "SERVICE_FILTER_LABEL_NAME"
 )
 
 // Global configuration for the application.
@@ -62,11 +64,12 @@ type GrafanaConfig struct {
 
 // Config defines full YAML configuration.
 type Config struct {
-	Identity             security.Identity `yaml:",omitempty"`
-	Server               Server            `yaml:",omitempty"`
-	PrometheusServiceURL string            `yaml:"prometheus_service_url,omitempty"`
-	IstioIdentityDomain  string            `yaml:"istio_identity_domain,omitempty"`
-	Grafana              GrafanaConfig     `yaml:"grafana,omitempty"`
+	Identity               security.Identity `yaml:",omitempty"`
+	Server                 Server            `yaml:",omitempty"`
+	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
+	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
+	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
+	ServiceFilterLabelName string            `yaml:"service_filter_label_name,omitempty"`
 }
 
 // NewConfig creates a default Config struct
@@ -94,6 +97,8 @@ func NewConfig() (c *Config) {
 	c.Grafana.Dashboard = strings.TrimSpace(getDefaultString(EnvGrafanaDashboard, "istio-dashboard"))
 	c.Grafana.VarServiceSource = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceSource, "var-source"))
 	c.Grafana.VarServiceDest = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceDest, "var-http_destination"))
+
+	c.ServiceFilterLabelName = strings.TrimSpace(getDefaultString(EnvServiceFilterLabelName, "app"))
 	return
 }
 

--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -1,8 +1,14 @@
 package kubernetes
 
 import (
+	"github.com/kiali/swscore/config"
+
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
+)
+
+const (
+	DeploymentFilterLabelName = "app"
 )
 
 type serviceResponse struct {
@@ -98,7 +104,7 @@ func filterByService(serviceName string, dl *v1beta1.DeploymentList) *v1beta1.De
 	var deployments []v1beta1.Deployment
 
 	for _, deployment := range dl.Items {
-		if deployment.ObjectMeta.Labels != nil && deployment.ObjectMeta.Labels["app"] == serviceName {
+		if deployment.ObjectMeta.Labels != nil && deployment.ObjectMeta.Labels[config.Get().ServiceFilterLabelName] == serviceName {
 			deployments = append(deployments, deployment)
 		}
 	}


### PR DESCRIPTION
Removing a magic string from deployments filtering within service details endpoint.
This was a suggestion from @lucasponce :) thx