### PR TITLE
SWS-309 Fix build after GitHub Organization renaming

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= SWS image:https://travis-ci.org/swift-sunshine/swscore.svg["Build Status", link="https://travis-ci.org/swift-sunshine/swscore"]
+= SWS image:https://travis-ci.org/kiali/swscore.svg["Build Status", link="https://travis-ci.org/kiali/swscore"]
 :toc: macro
 :toc-title:
 
@@ -23,16 +23,16 @@ These build instructions assume you have the following installed on your system:
 
 To build SWS:
 
-* Clone this repository inside a GOPATH. These instructions will use the example GOPATH of "/source/go/swift-sunshine/swscore" but you can use whatever you want. Just change the first line of the below instructions to use your GOPATH.
+* Clone this repository inside a GOPATH. These instructions will use the example GOPATH of "/source/go/kiali/swscore" but you can use whatever you want. Just change the first line of the below instructions to use your GOPATH.
 
 [source,shell]
 ----
-export GOPATH=/source/go/swift-sunshine/swscore
+export GOPATH=/source/go/kiali/swscore
 mkdir -p $GOPATH
 cd $GOPATH
-mkdir -p src/github.com/swift-sunshine
-cd src/github.com/swift-sunshine
-git clone git@github.com:swift-sunshine/swscore
+mkdir -p src/github.com/kiali
+cd src/github.com/kiali
+git clone git@github.com:kiali/swscore
 export PATH=${PATH}:${GOPATH}/bin
 ----
 
@@ -40,7 +40,7 @@ export PATH=${PATH}:${GOPATH}/bin
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make dep-install
 ----
 
@@ -50,7 +50,7 @@ You should only run this command if you add, remove, or modify a dependency. If 
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make dep-update
 ----
 
@@ -58,7 +58,7 @@ make dep-update
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make build
 ----
 
@@ -66,7 +66,7 @@ make build
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make test
 ----
 
@@ -88,7 +88,7 @@ Create the SWS docker image through the "docker" make target:
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make docker
 ----
 
@@ -135,7 +135,7 @@ Create the SWS docker image through the "docker" make target:
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make docker
 ----
 
@@ -143,7 +143,7 @@ Note that if you are using minikube, you can build the docker image and push it 
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make minikube-docker
 ----
 
@@ -187,7 +187,7 @@ Sometimes you may want to run SWS outside of any container environment, perhaps 
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make install
 make run
 ----
@@ -196,7 +196,7 @@ The "install" target installs the SWS executable in your GOPATH /bin directory s
 
 [source,shell]
 ----
-cd ${GOPATH}/src/github.com/swift-sunshine/swscore
+cd ${GOPATH}/src/github.com/kiali/swscore
 make install
 ${GOPATH}/bin/sws -config <your-config-file>
 ----
@@ -344,13 +344,13 @@ grafana:
 
 === Running the UI Outside the Core
 
-When developing the http://github.com/swift-sunshine/swsui[SWS UI] you will find it useful to run it outside of the core to make it easier to update the UI code and see the changes without having to recompile. The prefered approach for this is to use a proxy on the UI to mount the core. The process is described https://github.com/swift-sunshine/swsui#developing[here].
+When developing the http://github.com/kiali/swsui[SWS UI] you will find it useful to run it outside of the core to make it easier to update the UI code and see the changes without having to recompile. The prefered approach for this is to use a proxy on the UI to mount the core. The process is described https://github.com/kiali/swsui#developing[here].
 
 === Running A Locally Built UI Inside the Core
 
 If you are developing the UI on your local machine but you want to see it deployed and running inside of the core server, you can do so by setting the environment variable CONSOLE_VERSION to the value "local" when building the docker image via the `docker` target. By default, your UI's build/ directory is assumed to be in a directory called `swsui` that is a peer directory of the GOPATH root directory for the core server. If it is not, you can set the environment variable CONSOLE_LOCAL_DIR to the value of the path of the root directory for the UI such that `$CONSOLE_LOCAL_DIR/build` contains the generated build files for the UI.
 
-For example, if your GOPATH directory for the swscore project is `/source/swift-sunshine/swscore` and you have git cloned the swsui repository in `/source/swift-sunshine/swsui` then you do not need to set CONSOLE_LOCAL_DIR. You can embed your locally built console into the core docker image via:
+For example, if your GOPATH directory for the swscore project is `/source/kiali/swscore` and you have git cloned the swsui repository in `/source/kiali/swsui` then you do not need to set CONSOLE_LOCAL_DIR. You can embed your locally built console into the core docker image via:
 
 [source,shell]
 ----

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -5,7 +5,7 @@ This document gives the steps required to perform a release of SWS. This documen
 == Steps
 
 The steps to perform a release are very simple and easy to execute thanks to the way link:.travis.yml[Travis] is setup.
-Before running these steps, it is assumed the link:https://github.com/swift-sunshine/swscore/tree/master[master] branch is all up to date and includes all code that is to be released.
+Before running these steps, it is assumed the link:https://github.com/kiali/swscore/tree/master[master] branch is all up to date and includes all code that is to be released.
 
 1) Update the link:Makefile[] so the VERSION variable is set to the new version number of the upcoming release. For example,
 
@@ -42,7 +42,7 @@ Now that the release is done, you will want to bump up the version with a new ve
 Once the above steps have been performed, the release is complete.
 There is now a git tag that marks the code that produced the release and there are DockerHub images for that release.
 
-* link:https://github.com/swift-sunshine/swscore/tags[Git Tags]
+* link:https://github.com/kiali/swscore/tags[Git Tags]
 * DockerHub images:
 ** link:https://hub.docker.com/r/jmazzitelli/sws/tags/[SWS]
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/swift-sunshine/swscore/config/security"
-	"github.com/swift-sunshine/swscore/log"
+	"github.com/kiali/swscore/config/security"
+	"github.com/kiali/swscore/log"
 )
 
 // Environment vars can define some default values.

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/swift-sunshine/swscore
+package: github.com/kiali/swscore
 import:
 - package: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998

--- a/graph/cytoscape/cytoscape.go
+++ b/graph/cytoscape/cytoscape.go
@@ -18,9 +18,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/swift-sunshine/swscore/graph/options"
-	"github.com/swift-sunshine/swscore/graph/tree"
-	"github.com/swift-sunshine/swscore/log"
+	"github.com/kiali/swscore/graph/options"
+	"github.com/kiali/swscore/graph/tree"
+	"github.com/kiali/swscore/log"
 )
 
 type NodeData struct {

--- a/graph/vizceral/vizceral.go
+++ b/graph/vizceral/vizceral.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/swift-sunshine/swscore/graph/tree"
+	"github.com/kiali/swscore/graph/tree"
 )
 
 type Metadata struct {

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -7,10 +7,10 @@ import (
 
 	"k8s.io/api/core/v1"
 
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/kubernetes"
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/models"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/kubernetes"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/models"
 )
 
 type osRouteSupplier func(string, string) (string, error)

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/kiali/swscore/config"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 )
 

--- a/handlers/grafana_test.go
+++ b/handlers/grafana_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/swift-sunshine/swscore/config"
+	"github.com/kiali/swscore/config"
 	"k8s.io/api/core/v1"
 )
 

--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -47,12 +47,12 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
-	"github.com/swift-sunshine/swscore/graph/cytoscape"
-	"github.com/swift-sunshine/swscore/graph/options"
-	"github.com/swift-sunshine/swscore/graph/tree"
-	"github.com/swift-sunshine/swscore/graph/vizceral"
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/prometheus"
+	"github.com/kiali/swscore/graph/cytoscape"
+	"github.com/kiali/swscore/graph/options"
+	"github.com/kiali/swscore/graph/tree"
+	"github.com/kiali/swscore/graph/vizceral"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/prometheus"
 )
 
 // GraphNamespace is a REST http.HandlerFunc handling namespace-wide servicegraph

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -7,15 +7,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/swift-sunshine/swscore/prometheus/prometheustest"
+	"github.com/kiali/swscore/prometheus/prometheustest"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/prometheus"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/prometheus"
 )
 
 // Setup mock

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/models"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/models"
 )
 
 func NamespaceList(w http.ResponseWriter, r *http.Request) {

--- a/handlers/root.go
+++ b/handlers/root.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/swift-sunshine/swscore/status"
+	"github.com/kiali/swscore/status"
 )
 
 func Root(w http.ResponseWriter, r *http.Request) {

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/swift-sunshine/swscore/kubernetes"
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/models"
-	"github.com/swift-sunshine/swscore/prometheus"
+	"github.com/kiali/swscore/kubernetes"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/models"
+	"github.com/kiali/swscore/prometheus"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 )

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/assert"
 	"github.com/kiali/swscore/prometheus"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestServiceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)

--- a/handlers/services_test.go
+++ b/handlers/services_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/swift-sunshine/swscore/prometheus/prometheustest"
+	"github.com/kiali/swscore/prometheus/prometheustest"
 
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	"github.com/swift-sunshine/swscore/prometheus"
+	"github.com/kiali/swscore/prometheus"
 )
 
 // TestServiceMetricsDefault is unit test (testing request handling, not the prometheus client behaviour)

--- a/models/destination_policy.go
+++ b/models/destination_policy.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/kiali/swscore/kubernetes"
 )
 
 type DestinationPolicies []DestinationPolicy

--- a/models/namespace.go
+++ b/models/namespace.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/kiali/swscore/kubernetes"
 	"k8s.io/api/core/v1"
 )
 

--- a/models/route_rule.go
+++ b/models/route_rule.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/kiali/swscore/kubernetes"
 )
 
 type RouteRules []RouteRule

--- a/models/service.go
+++ b/models/service.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/kiali/swscore/kubernetes"
 
 	"k8s.io/api/core/v1"
 )

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/swift-sunshine/swscore/kubernetes"
+	"github.com/kiali/swscore/kubernetes"
 
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
-	"github.com/swift-sunshine/swscore/config"
+	"github.com/kiali/swscore/config"
 )
 
 // Client for Prometheus API.

--- a/prometheus/client_test.go
+++ b/prometheus/client_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/mock"
 	"github.com/kiali/swscore/config"
 	"github.com/kiali/swscore/prometheus/prometheustest"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/mock"
 )
 
 func setupMocked() (*Client, *prometheustest.PromAPIMock, error) {

--- a/prometheus/client_test.go
+++ b/prometheus/client_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/prometheus/prometheustest"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/prometheus/prometheustest"
 )
 
 func setupMocked() (*Client, *prometheustest.PromAPIMock, error) {

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
-	"github.com/swift-sunshine/swscore/config"
+	"github.com/kiali/swscore/config"
 )
 
 var (

--- a/routing/router.go
+++ b/routing/router.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/swift-sunshine/swscore/config"
+	"github.com/kiali/swscore/config"
 )
 
 // NewRouter creates the router with all API routes and the static files handler

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/swift-sunshine/swscore/config"
+	"github.com/kiali/swscore/config"
 )
 
 func TestDrawPathProperly(t *testing.T) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -3,7 +3,7 @@ package routing
 import (
 	"net/http"
 
-	"github.com/swift-sunshine/swscore/handlers"
+	"github.com/kiali/swscore/handlers"
 )
 
 // Route describes a single route

--- a/server/server.go
+++ b/server/server.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/config/security"
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/routing"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/config/security"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/routing"
 )
 
 type Server struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/config/security"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/config/security"
 )
 
 const (

--- a/sws.go
+++ b/sws.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/swift-sunshine/swscore/config"
-	"github.com/swift-sunshine/swscore/log"
-	"github.com/swift-sunshine/swscore/server"
-	"github.com/swift-sunshine/swscore/status"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/server"
+	"github.com/kiali/swscore/status"
 )
 
 // Identifies the build. These are set via ldflags during the build (see Makefile).


### PR DESCRIPTION
swscore would not build anymore after the GitHub organization rename.

Similar exercise would have to happen when we rename swscore (waiting on kevin's input)