### PR TITLE
Adding commit-msg which prepend branch name for SWS-XXX branches

### DIFF
--- a/hack/commit-msg
+++ b/hack/commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Automatically adds branch name at the begining of every commit message.
+NAME=$(git branch | grep '*' | sed 's/* //')
+
+if [[ "$NAME" == SWS* ]]
+then
+  echo "$NAME"': '$(cat "$1") > "$1"
+fi


### PR DESCRIPTION
This git hook prepend a branch name for each commit for SWS-XXX branches. It is really useful when you name your branches as your JIRAs. Forget to add the JIRA name to each commit manually.

I find this useful for me, but I don't know if it something we want to add to the repo. 