### PR TITLE
add clean-all make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ clean:
 	@rm -f sws
 	@rm -rf ${GOPATH}/bin/sws
 	@rm -rf ${GOPATH}/pkg/*
-	@rm -rf _output/*
+	@rm -rf _output/docker
+
+clean-all: clean
+	@rm -rf _output
 
 git-init:
 	@echo Setting Git Hooks


### PR DESCRIPTION
this was something @pilhuhn asked for.

Now if you make clean all the istio and ansible stuff you installed via hack stuff won't go away. do a make clean-all to clean everything.