### PR TITLE
SWS-250 Refactor - Ask K8s API to return deployments already filtered by label

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -91,3 +91,8 @@ func NewClient() (*IstioClient, error) {
 	}
 	return &client, nil
 }
+
+func GetLabeledListOptions(labelSelector string) *meta_v1.ListOptions {
+	return &meta_v1.ListOptions{
+		LabelSelector: labelSelector}
+}

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -1,0 +1,15 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetList(t *testing.T) {
+	assert := assert.New(t)
+
+	listOptions := GetLabeledListOptions("app=helloworld")
+
+	assert.Equal(listOptions.LabelSelector, "app=helloworld")
+}


### PR DESCRIPTION
Small but important refactor. Deployments were filtered by label in our side instead of asking k8s to do that.