### PR TITLE
sws-278 decorate cytoscape nodes and edges with more data

### DIFF
--- a/handlers/graph.go
+++ b/handlers/graph.go
@@ -39,7 +39,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -121,7 +120,7 @@ func buildNamespaceTrees(o options.Options, client *prometheus.Client) (trees []
 
 		rootService := string(sourceSvc)
 		md := make(map[string]interface{})
-		md["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, rootService, tree.UnknownVersion)
+		// md["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, rootService, tree.UnknownVersion)
 
 		root := tree.NewServiceNode(rootService, tree.UnknownVersion)
 		root.Parent = nil
@@ -164,7 +163,7 @@ func buildNamespaceTree(sn *tree.ServiceNode, start time.Time, seenNodes map[str
 		i := 0
 		for k, d := range destinations {
 			s := strings.Split(k, " ")
-			d["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, s[0], s[1])
+			// d["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, s[0], s[1])
 			child := tree.NewServiceNode(s[0], s[1])
 			child.Parent = sn
 			child.Metadata = d
@@ -256,7 +255,7 @@ func buildServiceTrees(o options.Options, client *prometheus.Client) (trees []tr
 		rootService := string(sourceSvc)
 		rootVersion := string(sourceVer)
 		md := make(map[string]interface{})
-		md["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, rootService, rootVersion)
+		// md["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, rootService, rootVersion)
 
 		root := tree.NewServiceNode(rootService, rootVersion)
 		root.Parent = nil
@@ -301,7 +300,7 @@ func buildServiceSubtree(sn *tree.ServiceNode, destinationSvc string, start time
 		i := 0
 		for k, d := range destinations {
 			s := strings.Split(k, " ")
-			d["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, s[0], s[1])
+			// d["link_prom_graph"] = linkPromGraph(client.Address(), o.Metric, s[0], s[1])
 			child := tree.NewServiceNode(s[0], s[1])
 			child.Parent = sn
 			child.Metadata = d
@@ -399,16 +398,16 @@ func toDestinations(sourceSvc, sourceVer string, vector model.Vector) (destinati
 	return destinations
 }
 
-func linkPromGraph(server, ts, name, version string) (link string) {
-	var promExpr string
-	if tree.UnknownVersion == version {
-		promExpr = fmt.Sprintf("%v{source_service=\"%v\",source_version=\"%v\"}", ts, name, version)
-	} else {
-		promExpr = fmt.Sprintf("%v{destination_service=\"%v\",destination_version=\"%v\"}", ts, name, version)
-	}
-	link = fmt.Sprintf("%v/graph?g0.range_input=1h&g0.tab=0&g0.expr=%v", server, url.QueryEscape(promExpr))
-	return link
-}
+//func linkPromGraph(server, ts, name, version string) (link string) {
+//	var promExpr string
+//	if tree.UnknownVersion == version {
+//		promExpr = fmt.Sprintf("%v{source_service=\"%v\",source_version=\"%v\"}", ts, name, version)
+//	} else {
+//		promExpr = fmt.Sprintf("%v{destination_service=\"%v\",destination_version=\"%v\"}", ts, name, version)
+//	}
+//	link = fmt.Sprintf("%v/graph?g0.range_input=1h&g0.tab=0&g0.expr=%v", server, url.QueryEscape(promExpr))
+//	return link
+//}
 
 // TF is the TimeFormat for printing timestamp
 const TF = "2006-01-02 15:04:05"

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -96,8 +96,21 @@ func TestNamespaceGraph(t *testing.T) {
 	q3m3 := model.Metric{
 		"destination_service": "details.istio-system.svc.cluster.local",
 		"destination_version": "v1",
-		"response_code":       "200"}
+		"response_code":       "300"}
 	q3m4 := model.Metric{
+		"destination_service": "details.istio-system.svc.cluster.local",
+		"destination_version": "v1",
+		"response_code":       "400"}
+	q3m5 := model.Metric{
+		"destination_service": "details.istio-system.svc.cluster.local",
+		"destination_version": "v1",
+		"response_code":       "500"}
+	q3m6 := model.Metric{
+		"destination_service": "details.istio-system.svc.cluster.local",
+		"destination_version": "v1",
+		"response_code":       "200"}
+
+	q3m7 := model.Metric{
 		"destination_service": "productpage.istio-system.svc.cluster.local",
 		"destination_version": "v1",
 		"response_code":       "200"}
@@ -116,6 +129,15 @@ func TestNamespaceGraph(t *testing.T) {
 			Value:  20},
 		&model.Sample{
 			Metric: q3m4,
+			Value:  20},
+		&model.Sample{
+			Metric: q3m5,
+			Value:  20},
+		&model.Sample{
+			Metric: q3m6,
+			Value:  20},
+		&model.Sample{
+			Metric: q3m7,
 			Value:  20}}
 
 	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"

--- a/handlers/testdata/test_namespace_graph.expected
+++ b/handlers/testdata/test_namespace_graph.expected
@@ -7,7 +7,11 @@
           "text": "details (v1)",
           "service": "details.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22details.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "80.00",
+          "rate3XX": "20.00",
+          "rate4XX": "20.00",
+          "rate5XX": "20.00",
+          "rateErr": "60.00"
         }
       },
       {
@@ -15,8 +19,7 @@
           "id": "n7",
           "text": "ingress",
           "service": "ingress.istio-system.svc.cluster.local",
-          "version": "unknown",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bsource_service%3D%22ingress.istio-system.svc.cluster.local%22%2Csource_version%3D%22unknown%22%7D"
+          "version": "unknown"
         }
       },
       {
@@ -25,7 +28,7 @@
           "text": "productpage (v1) \u003c20.00pm\u003e",
           "service": "productpage.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22productpage.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "150.00"
         }
       },
       {
@@ -34,14 +37,15 @@
           "text": "ratings (v1)",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22ratings.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "40.00"
         }
       },
       {
         "data": {
           "id": "n8",
           "text": "reviews",
-          "service": "reviews.istio-system.svc.cluster.local"
+          "service": "reviews.istio-system.svc.cluster.local",
+          "groupBy": "version"
         }
       },
       {
@@ -51,7 +55,7 @@
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "20.00"
         }
       },
       {
@@ -61,7 +65,7 @@
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D"
+          "rate": "20.00"
         }
       },
       {
@@ -71,7 +75,7 @@
           "parent": "n8",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D"
+          "rate": "20.00"
         }
       },
       {
@@ -79,8 +83,7 @@
           "id": "n0",
           "text": "unknown",
           "service": "unknown",
-          "version": "unknown",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bsource_service%3D%22unknown%22%2Csource_version%3D%22unknown%22%7D"
+          "version": "unknown"
         }
       }
     ],
@@ -91,7 +94,8 @@
           "source": "n0",
           "target": "n1",
           "text": "50.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "50.00"
         }
       },
       {
@@ -99,8 +103,13 @@
           "id": "e1",
           "source": "n1",
           "target": "n2",
-          "text": "20.00ps",
-          "color": "green"
+          "text": "80.00ps (err=75.00%)",
+          "color": "red",
+          "rate": "80.00",
+          "rate3XX": "20.00",
+          "rate4XX": "20.00",
+          "rate5XX": "20.00",
+          "rateErr": "60.00"
         }
       },
       {
@@ -109,7 +118,8 @@
           "source": "n1",
           "target": "n3",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -118,7 +128,8 @@
           "source": "n1",
           "target": "n4",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -127,7 +138,8 @@
           "source": "n1",
           "target": "n6",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -136,7 +148,8 @@
           "source": "n4",
           "target": "n5",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -145,7 +158,8 @@
           "source": "n6",
           "target": "n5",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -154,7 +168,8 @@
           "source": "n7",
           "target": "n1",
           "text": "100.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "100.00"
         }
       }
     ]

--- a/handlers/testdata/test_service_graph.expected
+++ b/handlers/testdata/test_service_graph.expected
@@ -6,8 +6,7 @@
           "id": "n0",
           "text": "productpage (v1)",
           "service": "productpage.istio-system.svc.cluster.local",
-          "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22productpage.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "version": "v1"
         }
       },
       {
@@ -16,14 +15,15 @@
           "text": "ratings (v1)",
           "service": "ratings.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22ratings.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "40.00"
         }
       },
       {
         "data": {
           "id": "n5",
           "text": "reviews",
-          "service": "reviews.istio-system.svc.cluster.local"
+          "service": "reviews.istio-system.svc.cluster.local",
+          "groupBy": "version"
         }
       },
       {
@@ -33,7 +33,7 @@
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v1",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+          "rate": "20.00"
         }
       },
       {
@@ -43,7 +43,7 @@
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v2",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D"
+          "rate": "20.00"
         }
       },
       {
@@ -53,7 +53,7 @@
           "parent": "n5",
           "service": "reviews.istio-system.svc.cluster.local",
           "version": "v3",
-          "link_prom_graph": "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D"
+          "rate": "20.00"
         }
       }
     ],
@@ -64,7 +64,8 @@
           "source": "n0",
           "target": "n1",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -73,7 +74,8 @@
           "source": "n0",
           "target": "n2",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -82,7 +84,8 @@
           "source": "n0",
           "target": "n4",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -91,7 +94,8 @@
           "source": "n2",
           "target": "n3",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       },
       {
@@ -100,7 +104,8 @@
           "source": "n4",
           "target": "n3",
           "text": "20.00ps",
-          "color": "green"
+          "color": "green",
+          "rate": "20.00"
         }
       }
     ]


### PR DESCRIPTION
Edge App fields (if non-zero):
  Rate	   // total requests per second
  Rate3xx  // requests per second returning 3xx errors
  Rate4xx  // requests per second returning 4xx errors
  Rate5xx  // requests per second returning 5xx errors
  RateErr  // total requests per second returning 3|4|5xx errors

Node App Fields (if non-zero, for rate fields)
  Service  // service name
  Version  // service version
  GroupBy  // set on compound nodes. valid values: [ 'version' ]
  Rate	   // aggregate total requests per second
  Rate3xx  // aggregate requests per second returning 3xx errors
  Rate4xx  // aggregate requests per second returning 4xx errors
  Rate5xx  // aggregate requests per second returning 5xx errors
  RateErr  // aggregate total requests per second returning 3|4|5xx errors

  * aggregates are for all incoming edges

note: the link_prom_graph field has been removed (commented out for now)
      as no plan has emerged for its use.