### PR TITLE
SWS-327 Fix fetch Istio Rule with non supported handlers/instances

### DIFF
--- a/models/istio_rule.go
+++ b/models/istio_rule.go
@@ -117,6 +117,9 @@ func CastIstioRuleAction(action *kubernetes.IstioRuleAction) *IstioRuleAction {
 
 func CastIstioHandler(handler kubernetes.IstioObject) *IstioHandler {
 	istioHandler := IstioHandler{}
+	if handler == nil {
+		return nil
+	}
 	istioHandler.Name = handler.GetObjectMeta().Name
 	istioHandler.Adapter = handler.GetSpec()["adapter"].(string)
 	delete(handler.GetSpec(), "adapter")
@@ -126,6 +129,9 @@ func CastIstioHandler(handler kubernetes.IstioObject) *IstioHandler {
 
 func CastIstioInstance(instance kubernetes.IstioObject) *IstioInstance {
 	istioInstance := IstioInstance{}
+	if instance == nil {
+		return nil
+	}
 	istioInstance.Name = instance.GetObjectMeta().Name
 	istioInstance.Template = instance.GetSpec()["template"].(string)
 	delete(instance.GetSpec(), "template")

--- a/models/istio_rule_test.go
+++ b/models/istio_rule_test.go
@@ -70,6 +70,16 @@ func TestIstioRuleDetailsParsing(t *testing.T) {
 	assert.Equal("source.labels[\"app\"]", value)
 }
 
+func TestIstioRuleWithNotSupportedHandlersOrInstances(t *testing.T) {
+	assert := assert.New(t)
+	istioDetails := CastIstioRuleDetails(fakeRuleNotSupportedHandlersDetails())
+	assert.Equal(1, len(istioDetails.Actions))
+	assert.Nil(istioDetails.Actions[0].Handler)
+	instances := istioDetails.Actions[0].Instances
+	assert.Equal(1, len(instances))
+	assert.Nil(instances[0])
+}
+
 func fakeCheckFromCustomerRule() kubernetes.IstioObject {
 	checkfromcustomerRule := kubernetes.MockIstioObject{}
 	checkfromcustomerRule.Name = "checkfromcustomer"
@@ -145,4 +155,37 @@ func fakeCheckFromCustomerDetails() *kubernetes.IstioRuleDetails {
 	istioRulesDetails.Rule = fakeCheckFromCustomerRule()
 	istioRulesDetails.Actions = fakeCheckFromCustomerActions()
 	return &istioRulesDetails
+}
+
+func fakeStdioRule() kubernetes.IstioObject {
+	stdioRule := kubernetes.MockIstioObject{}
+	stdioRule.Name = "stdio"
+	stdioRule.Spec = map[string]interface{}{
+		"match": "true",
+		"actions": []map[string]interface{}{
+			{
+				"handler": "handler.stdio",
+				"instances": []string{
+					"accesslog.logentry",
+				},
+			},
+		},
+	}
+	return &stdioRule
+}
+
+func fakeSdtioUnsupportedHandlersInstances() []*kubernetes.IstioRuleAction {
+	actions := make([]*kubernetes.IstioRuleAction, 0)
+	actions = append(actions, &kubernetes.IstioRuleAction{
+		Handler:   nil,
+		Instances: []kubernetes.IstioObject{nil},
+	})
+	return actions
+}
+
+func fakeRuleNotSupportedHandlersDetails() *kubernetes.IstioRuleDetails {
+	istioRuleDetails := kubernetes.IstioRuleDetails{}
+	istioRuleDetails.Rule = fakeStdioRule()
+	istioRuleDetails.Actions = fakeSdtioUnsupportedHandlersInstances()
+	return &istioRuleDetails
 }


### PR DESCRIPTION
- A non supported handler/instance is converted in a nil object but prevent to fail
