### PR TITLE
SWS-216: Add request_error_count metrics

### DIFF
--- a/handlers/services.go
+++ b/handlers/services.go
@@ -71,6 +71,10 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplie
 			return
 		}
 	}
+	version := ""
+	if versions, ok := queryParams["version"]; ok && len(versions) > 0 {
+		version = versions[0]
+	}
 	var byLabelsIn []string
 	var byLabelsOut []string
 	if lblsin, ok := queryParams["byLabelsIn[]"]; ok && len(lblsin) > 0 {
@@ -85,7 +89,8 @@ func getServiceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplie
 		RespondWithError(w, http.StatusServiceUnavailable, "Prometheus client error: "+err.Error())
 		return
 	}
-	metrics := prometheusClient.GetServiceMetrics(namespace, service, duration, step, rateInterval, byLabelsIn, byLabelsOut)
+
+	metrics := prometheusClient.GetServiceMetrics(namespace, service, version, duration, step, rateInterval, byLabelsIn, byLabelsOut)
 	RespondWithJSON(w, http.StatusOK, metrics)
 }
 

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -85,10 +85,10 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 
 // GetServiceMetrics returns the Health and Metrics related to the provided service identified by its namespace and service name.
 // Health might be nil when unavailable
-func (in *Client) GetServiceMetrics(namespace string, servicename string, duration time.Duration, step time.Duration,
+func (in *Client) GetServiceMetrics(namespace string, servicename string, version string, duration time.Duration, step time.Duration,
 	rateInterval string, byLabelsIn []string, byLabelsOut []string) Metrics {
 
-	metrics := getServiceMetrics(in.api, namespace, servicename, duration, step, rateInterval, byLabelsIn, byLabelsOut)
+	metrics := getServiceMetrics(in.api, namespace, servicename, version, duration, step, rateInterval, byLabelsIn, byLabelsOut)
 	health := getServiceHealth(in.api, namespace, servicename)
 	metrics.Health = health
 


### PR DESCRIPTION
Adding one more behavior to the metrics endpoint:
* Pass query param component=details (or nothing) to trigger current behavior.
* Pass query param component=summaryPanel to trigger new behavior.

New behavior is to only return request_count_{in/out} metrics and also request_error_count_{in/out} metrics.

This is what should be needed to populate the "sparklines" of the side panel in the service graph.
