### PR TITLE
SWS-253: Embed autoscalers in each deployment

### DIFF
--- a/kubernetes/kubernetes_service.go
+++ b/kubernetes/kubernetes_service.go
@@ -116,7 +116,7 @@ func (in *IstioClient) GetServiceDetails(namespace string, serviceName string) (
 	if autoscalersResponse.err != nil {
 		return nil, autoscalersResponse.err
 	}
-	serviceDetails.Autoscalers = filterAutoscalersByDeployments(getDeploymentNames(serviceDetails.Deployments), autoscalersResponse.autoscalers)
+	serviceDetails.Autoscalers = autoscalersResponse.autoscalers
 
 	return &serviceDetails, nil
 }

--- a/models/autoscalers.go
+++ b/models/autoscalers.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"k8s.io/api/autoscaling/v1"
 	"time"
+
+	"k8s.io/api/autoscaling/v1"
 )
 
-type Autoscalers []Autoscaler
 type Autoscaler struct {
 	Name      string            `json:"name"`
 	Labels    map[string]string `json:"labels"`
@@ -20,18 +20,6 @@ type Autoscaler struct {
 	CurrentReplicas                 int32  `json:"current_replicas"`
 	DesiredReplicas                 int32  `json:"desired_replicas"`
 	CurrentCPUUtilizationPercentage int32  `json:"current_CPU_utilization_percentage,omitempty"`
-}
-
-func (autoscalers *Autoscalers) Parse(ds *v1.HorizontalPodAutoscalerList) {
-	if ds == nil {
-		return
-	}
-
-	for _, autoscaler := range ds.Items {
-		casted := Autoscaler{}
-		casted.Parse(&autoscaler)
-		*autoscalers = append(*autoscalers, casted)
-	}
 }
 
 func (autoscaler *Autoscaler) Parse(d *v1.HorizontalPodAutoscaler) {

--- a/models/deployment.go
+++ b/models/deployment.go
@@ -1,11 +1,13 @@
 package models
 
 import (
-	"k8s.io/api/apps/v1beta1"
 	"time"
+
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/autoscaling/v1"
 )
 
-type Deployments []Deployment
+type Deployments []*Deployment
 type Deployment struct {
 	Name                string            `json:"name"`
 	Labels              map[string]string `json:"labels"`
@@ -13,6 +15,7 @@ type Deployment struct {
 	Replicas            int32             `json:"replicas"`
 	AvailableReplicas   int32             `json:"available_replicas"`
 	UnavailableReplicas int32             `json:"unavailable_replicas"`
+	Autoscaler          Autoscaler        `json:"autoscaler"`
 }
 
 func (deployments *Deployments) Parse(ds *v1beta1.DeploymentList) {
@@ -23,7 +26,7 @@ func (deployments *Deployments) Parse(ds *v1beta1.DeploymentList) {
 	for _, deployment := range ds.Items {
 		casted := Deployment{}
 		casted.Parse(&deployment)
-		*deployments = append(*deployments, casted)
+		*deployments = append(*deployments, &casted)
 	}
 }
 
@@ -34,4 +37,18 @@ func (deployment *Deployment) Parse(d *v1beta1.Deployment) {
 	deployment.Replicas = d.Status.Replicas
 	deployment.AvailableReplicas = d.Status.AvailableReplicas
 	deployment.UnavailableReplicas = d.Status.UnavailableReplicas
+}
+
+func (deployments *Deployments) AddAutoscalers(as *v1.HorizontalPodAutoscalerList) {
+	if as == nil {
+		return
+	}
+
+	for _, deployment := range *deployments {
+		for _, autoscaler := range as.Items {
+			if deployment.Name == autoscaler.Spec.ScaleTargetRef.Name {
+				deployment.Autoscaler.Parse(&autoscaler)
+			}
+		}
+	}
 }

--- a/models/service.go
+++ b/models/service.go
@@ -27,7 +27,6 @@ type Service struct {
 	DestinationPolicies DestinationPolicies `json:"destination_policies"`
 	Dependencies        map[string][]string `json:"dependencies"`
 	Deployments         Deployments         `json:"deployments"`
-	Autoscalers         Autoscalers         `json:"autoscalers"`
 }
 
 func GetServicesByNamespace(namespaceName string) ([]ServiceOverview, error) {
@@ -77,7 +76,7 @@ func (s *Service) setKubernetesDetails(serviceDetails *kubernetes.ServiceDetails
 
 	(&s.Endpoints).Parse(serviceDetails.Endpoints)
 	(&s.Deployments).Parse(serviceDetails.Deployments)
-	(&s.Autoscalers).Parse(serviceDetails.Autoscalers)
+	(&s.Deployments).AddAutoscalers(serviceDetails.Autoscalers)
 }
 
 func (s *Service) setIstioDetails(istioDetails *kubernetes.IstioDetails) {

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -41,24 +41,15 @@ func TestServiceDetailParsing(t *testing.T) {
 				Port{Name: "http", Protocol: "TCP", Port: 3001},
 				Port{Name: "http", Protocol: "TCP", Port: 3000},
 			}}})
-	assert.Equal(service.Deployments, Deployments{
-		Deployment{
-			Name:                "reviews-v1",
-			Labels:              map[string]string{"apps": "reviews", "version": "v1"},
-			CreatedAt:           "2018-03-08T17:44:00+03:00",
-			Replicas:            3,
-			AvailableReplicas:   1,
-			UnavailableReplicas: 2},
-		Deployment{
-			Name:                "reviews-v2",
-			Labels:              map[string]string{"apps": "reviews", "version": "v2"},
-			CreatedAt:           "2018-03-08T17:45:00+03:00",
-			Replicas:            3,
-			AvailableReplicas:   3,
-			UnavailableReplicas: 0}})
 
-	assert.Equal(service.Autoscalers, Autoscalers{
-		Autoscaler{
+	assert.Equal(*service.Deployments[0], Deployment{
+		Name:                "reviews-v1",
+		Labels:              map[string]string{"apps": "reviews", "version": "v1"},
+		CreatedAt:           "2018-03-08T17:44:00+03:00",
+		Replicas:            3,
+		AvailableReplicas:   1,
+		UnavailableReplicas: 2,
+		Autoscaler: Autoscaler{
 			Name:                            "reviews-v1",
 			Labels:                          map[string]string{"apps": "reviews", "version": "v1"},
 			CreatedAt:                       "2018-03-08T17:44:00+03:00",
@@ -68,9 +59,16 @@ func TestServiceDetailParsing(t *testing.T) {
 			CurrentReplicas:                 3,
 			DesiredReplicas:                 4,
 			ObservedGeneration:              50,
-			CurrentCPUUtilizationPercentage: 70,
-		},
-		Autoscaler{
+			CurrentCPUUtilizationPercentage: 70}})
+
+	assert.Equal(*service.Deployments[1], Deployment{
+		Name:                "reviews-v2",
+		Labels:              map[string]string{"apps": "reviews", "version": "v2"},
+		CreatedAt:           "2018-03-08T17:45:00+03:00",
+		Replicas:            3,
+		AvailableReplicas:   3,
+		UnavailableReplicas: 0,
+		Autoscaler: Autoscaler{
 			Name:                            "reviews-v2",
 			Labels:                          map[string]string{"apps": "reviews", "version": "v2"},
 			CreatedAt:                       "2018-03-08T17:45:00+03:00",
@@ -80,8 +78,7 @@ func TestServiceDetailParsing(t *testing.T) {
 			CurrentReplicas:                 3,
 			DesiredReplicas:                 2,
 			ObservedGeneration:              50,
-			CurrentCPUUtilizationPercentage: 30,
-		}})
+			CurrentCPUUtilizationPercentage: 30}})
 
 	// Istio Details
 	assert.Equal(service.RouteRules, RouteRules{
@@ -210,6 +207,8 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 					Labels:            map[string]string{"apps": "reviews", "version": "v1"},
 					CreationTimestamp: meta_v1.NewTime(t1)},
 				Spec: autoscalingV1.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingV1.CrossVersionObjectReference{
+						Name: "reviews-v1"},
 					MinReplicas:                    &[]int32{1}[0],
 					MaxReplicas:                    10,
 					TargetCPUUtilizationPercentage: &[]int32{50}[0]},
@@ -224,6 +223,8 @@ func fakeServiceDetails() *kubernetes.ServiceDetails {
 					Labels:            map[string]string{"apps": "reviews", "version": "v2"},
 					CreationTimestamp: meta_v1.NewTime(t2)},
 				Spec: autoscalingV1.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingV1.CrossVersionObjectReference{
+						Name: "reviews-v2"},
 					MinReplicas:                    &[]int32{1}[0],
 					MaxReplicas:                    10,
 					TargetCPUUtilizationPercentage: &[]int32{50}[0]},


### PR DESCRIPTION
Instead of having two different lists in service details, this PR adds an autoscaler within the deployment object.

![nested-autoscalers-deployments](https://user-images.githubusercontent.com/613814/37527801-2c2e84ee-2933-11e8-8c6a-605e5ebb62a5.png)

