### PR TITLE
KIALI-241 Add missing RouteRules attributes

### DIFF
--- a/models/route_rule.go
+++ b/models/route_rule.go
@@ -6,11 +6,21 @@ import (
 
 type RouteRules []RouteRule
 type RouteRule struct {
-	Name        string      `json:"name"`
-	Destination interface{} `json:"destination"`
-	Precedence  interface{} `json:"precedence"`
-	Route       interface{} `json:"route"`
-	Match       interface{} `json:"match"`
+	Name             string      `json:"name"`
+	Destination      interface{} `json:"destination"`
+	Precedence       interface{} `json:"precedence"`
+	Match            interface{} `json:"match"`
+	Route            interface{} `json:"route"`
+	Redirect         interface{} `json:"redirect"`
+	Rewrite          interface{} `json:"rewrite"`
+	WebsocketUpgrade interface{} `json:"websocketUpgrade"`
+	HttpReqTimeout   interface{} `json:"httpReqTimeout"`
+	HttpReqRetries   interface{} `json:"httpReqRetries"`
+	HttpFault        interface{} `json:"httpFault"`
+	L4Fault          interface{} `json:"l4Fault"`
+	Mirror           interface{} `json:"mirror"`
+	CorsPolicy       interface{} `json:"corsPolicy"`
+	AppendHeaders    interface{} `json:"appendHeaders"`
 }
 
 func (rules *RouteRules) Parse(routeRules []kubernetes.IstioObject) {
@@ -25,6 +35,16 @@ func (rule *RouteRule) Parse(routeRule kubernetes.IstioObject) {
 	rule.Name = routeRule.GetObjectMeta().Name
 	rule.Destination = routeRule.GetSpec()["destination"]
 	rule.Precedence = routeRule.GetSpec()["precedence"]
-	rule.Route = routeRule.GetSpec()["route"]
 	rule.Match = routeRule.GetSpec()["match"]
+	rule.Route = routeRule.GetSpec()["route"]
+	rule.Redirect = routeRule.GetSpec()["redirect"]
+	rule.Rewrite = routeRule.GetSpec()["rewrite"]
+	rule.WebsocketUpgrade = routeRule.GetSpec()["websocketUpgrade"]
+	rule.HttpReqTimeout = routeRule.GetSpec()["httpReqTimeout"]
+	rule.HttpReqRetries = routeRule.GetSpec()["httpReqRetries"]
+	rule.HttpFault = routeRule.GetSpec()["httpFault"]
+	rule.L4Fault = routeRule.GetSpec()["l4Fault"]
+	rule.Mirror = routeRule.GetSpec()["mirror"]
+	rule.CorsPolicy = routeRule.GetSpec()["corsPolicy"]
+	rule.AppendHeaders = routeRule.GetSpec()["appendHeaders"]
 }

--- a/models/service_test.go
+++ b/models/service_test.go
@@ -91,7 +91,13 @@ func TestServiceDetailParsing(t *testing.T) {
 			Route: map[string]map[string]string{
 				"labels": {
 					"name":      "version",
-					"namespace": "v1"}}},
+					"namespace": "v1"}},
+			HttpFault: map[string]map[string]string{
+				"abort": {
+					"percent":    "50",
+					"httpStatus": "503",
+				},
+			}},
 		RouteRule{
 			Destination: map[string]string{
 				"name":      "reviews",
@@ -248,7 +254,12 @@ func fakeIstioDetails() *kubernetes.IstioDetails {
 			"route": map[string]map[string]string{
 				"labels": map[string]string{
 					"name":      "version",
-					"namespace": "v1"}}},
+					"namespace": "v1"}},
+			"httpFault": map[string]map[string]string{
+				"abort": map[string]string{
+					"percent":    "50",
+					"httpStatus": "503",
+				}}},
 	}
 	route2 := kubernetes.MockIstioObject{
 		Spec: map[string]interface{}{


### PR DESCRIPTION
This PR is to add the missing fields used for the RouteRule object.
In the previous Sprint we only added the fields we used from examples, but now we are targeting more complex examples makes sense to expose all potential fields that can be used in the routes as in some way we need to show them in the UI.