### PR TITLE
KIALI-330 Add backend support for namespace metrics

### DIFF
--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/kiali/swscore/log"
 	"github.com/kiali/swscore/models"
+	"github.com/kiali/swscore/prometheus"
 )
 
 func NamespaceList(w http.ResponseWriter, r *http.Request) {
@@ -16,4 +18,17 @@ func NamespaceList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	RespondWithJSON(w, http.StatusOK, namespaces)
+}
+
+// NamespaceMetrics is the API handler to fetch metrics to be displayed, related to all
+// services in the namespace
+func NamespaceMetrics(w http.ResponseWriter, r *http.Request) {
+	getNamespaceMetrics(w, r, prometheus.NewClient)
+}
+
+// getServiceMetrics (mock-friendly version)
+func getNamespaceMetrics(w http.ResponseWriter, r *http.Request, promClientSupplier func() (*prometheus.Client, error)) {
+	vars := mux.Vars(r)
+	namespace := vars["namespace"]
+	getMetrics(w, r, prometheus.NewClient, namespace, "")
 }

--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -86,7 +86,7 @@ func (in *Client) GetSourceServices(namespace string, servicename string) (map[s
 // GetServiceMetrics returns the Metrics related to the provided service identified by its namespace and service name.
 func (in *Client) GetServiceMetrics(namespace string, servicename string, version string, duration time.Duration, step time.Duration,
 	rateInterval string, byLabelsIn []string, byLabelsOut []string) Metrics {
-	return getServiceMetrics(in.api, namespace, servicename, version, duration, step, rateInterval, byLabelsIn, byLabelsOut)
+	return getServiceMetrics(in.api, namespace, servicename, version, duration, step, rateInterval, byLabelsIn, byLabelsOut, EQUALS)
 }
 
 // GetServiceHealth returns the Health related to the provided service identified by its namespace and service name.
@@ -94,6 +94,15 @@ func (in *Client) GetServiceMetrics(namespace string, servicename string, versio
 // When the health is unavailable, total number of replicas will be 0.
 func (in *Client) GetServiceHealth(namespace string, servicename string) Health {
 	return getServiceHealth(in.api, namespace, servicename)
+}
+
+// GetNamespaceMetrics returns the Metrics described by the optional service pattern ("" for all), and optional
+// version, for the given namespace. Use GetServiceMetrics if you don't need pattern matching.
+func (in *Client) GetNamespaceMetrics(namespace, servicePattern, version string, duration, step time.Duration,
+	rateInterval string, byLabelsIn, byLabelsOut []string) Metrics {
+
+	metrics := getServiceMetrics(in.api, namespace, servicePattern, version, duration, step, rateInterval, byLabelsIn, byLabelsOut, REGEX)
+	return metrics
 }
 
 // API returns the Prometheus V1 HTTP API for performing calls not supported natively by this client

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -87,6 +87,12 @@ func NewRoutes() (r *Routes) {
 			handlers.ServiceHealth,
 		},
 		{
+			"NamespaceMetrics",
+			"GET",
+			"/api/namespaces/{namespace}/metrics",
+			handlers.NamespaceMetrics,
+		},
+		{
 			// Supported query parameters:
 			// vendor:         cytoscape (default) | vizceral
 			// metric:         Prometheus metric name used to generate the dependency graph (default=istio_request_count)


### PR DESCRIPTION
This is analogous to the existing service metrics support but allows for
a an optional service pattern (regex) as opposed to an explicit service.
Without a pattern it will aggregate on all services in the namespace.

@jotak Please review.  I think this is needed to gather aggregate metrics when querying across different, or all, services in a namespace.  We needed it to support traffic summary for the namespace graph.  Thanks. Jay.