### PR TITLE
[KIALI-242] Add Jaeger Info to Backend

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -345,6 +345,29 @@ grafana:
   var_service_dest: VALUE
 ----
 
+|`JAEGER_URL`
+|The URL to the Jaeger server. When not set, the URL may be automatically detected from OpenShift or Kubernetes API.
+[source,yaml]
+----
+jaeger:
+  url: VALUE
+----
+
+|`JAEGER_SERVICE_NAMESPACE`
+|The Kubernetes namespace that holds the Jaeger service. This configuration is ignored if `JAEGER_URL` is set. Default is `istio-system`.
+[source,yaml]
+----
+jaeger:
+  service_namespace: VALUE
+----
+
+|`JAEGER_SERVICE`
+|The OpenShift route name or the Kubernetes service name for Jaeger. This configuration is ignored if `JAEGER_URL` is set. Default is `jaeger-query`.
+[source,yaml]
+----
+jaeger:
+  service: VALUE
+----
 |===
 
 == Additional Notes

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,11 @@ const (
 	EnvGrafanaVarServiceSource = "GRAFANA_VAR_SERVICE_SOURCE"
 	EnvGrafanaVarServiceDest   = "GRAFANA_VAR_SERVICE_DEST"
 
+	EnvJaegerDisplayLink      = "JAEGER_DISPLAY_LINK"
+	EnvJaegerURL              = "JAEGER_URL"
+	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
+	EnvJaegerService          = "JAEGER_SERVICE"
+
 	EnvServiceFilterLabelName = "SERVICE_FILTER_LABEL_NAME"
 )
 
@@ -62,6 +67,14 @@ type GrafanaConfig struct {
 	VarServiceDest   string `yaml:"var_service_dest"`
 }
 
+// JaegerConfig describes configuration used for jaeger links
+type JaegerConfig struct {
+	DisplayLink      bool   `yaml:"display_link"`
+	URL              string `yaml:"url"`
+	ServiceNamespace string `yaml:"service_namespace"`
+	Service          string `yaml:"service"`
+}
+
 // Config defines full YAML configuration.
 type Config struct {
 	Identity               security.Identity `yaml:",omitempty"`
@@ -69,6 +82,7 @@ type Config struct {
 	PrometheusServiceURL   string            `yaml:"prometheus_service_url,omitempty"`
 	IstioIdentityDomain    string            `yaml:"istio_identity_domain,omitempty"`
 	Grafana                GrafanaConfig     `yaml:"grafana,omitempty"`
+	Jaeger                 JaegerConfig      `yaml:"jaeger,omitempty"`
 	ServiceFilterLabelName string            `yaml:"service_filter_label_name,omitempty"`
 }
 
@@ -97,6 +111,11 @@ func NewConfig() (c *Config) {
 	c.Grafana.Dashboard = strings.TrimSpace(getDefaultString(EnvGrafanaDashboard, "istio-dashboard"))
 	c.Grafana.VarServiceSource = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceSource, "var-source"))
 	c.Grafana.VarServiceDest = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceDest, "var-http_destination"))
+
+	c.Jaeger.DisplayLink = getDefaultBool(EnvJaegerDisplayLink, true)
+	c.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
+	c.Jaeger.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvJaegerServiceNamespace, "istio-system"))
+	c.Jaeger.Service = strings.TrimSpace(getDefaultString(EnvJaegerService, "jaeger-query"))
 
 	c.ServiceFilterLabelName = strings.TrimSpace(getDefaultString(EnvServiceFilterLabelName, "app"))
 	return

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,6 @@ const (
 	EnvGrafanaVarServiceSource = "GRAFANA_VAR_SERVICE_SOURCE"
 	EnvGrafanaVarServiceDest   = "GRAFANA_VAR_SERVICE_DEST"
 
-	EnvJaegerDisplayLink      = "JAEGER_DISPLAY_LINK"
 	EnvJaegerURL              = "JAEGER_URL"
 	EnvJaegerServiceNamespace = "JAEGER_SERVICE_NAMESPACE"
 	EnvJaegerService          = "JAEGER_SERVICE"
@@ -69,7 +68,6 @@ type GrafanaConfig struct {
 
 // JaegerConfig describes configuration used for jaeger links
 type JaegerConfig struct {
-	DisplayLink      bool   `yaml:"display_link"`
 	URL              string `yaml:"url"`
 	ServiceNamespace string `yaml:"service_namespace"`
 	Service          string `yaml:"service"`
@@ -112,7 +110,6 @@ func NewConfig() (c *Config) {
 	c.Grafana.VarServiceSource = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceSource, "var-source"))
 	c.Grafana.VarServiceDest = strings.TrimSpace(getDefaultString(EnvGrafanaVarServiceDest, "var-http_destination"))
 
-	c.Jaeger.DisplayLink = getDefaultBool(EnvJaegerDisplayLink, true)
 	c.Jaeger.URL = strings.TrimSpace(getDefaultString(EnvJaegerURL, ""))
 	c.Jaeger.ServiceNamespace = strings.TrimSpace(getDefaultString(EnvJaegerServiceNamespace, "istio-system"))
 	c.Jaeger.Service = strings.TrimSpace(getDefaultString(EnvJaegerService, "jaeger-query"))

--- a/handlers/grafana.go
+++ b/handlers/grafana.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/api/core/v1"
 
 	"github.com/kiali/swscore/config"
-	"github.com/kiali/swscore/kubernetes"
 	"github.com/kiali/swscore/log"
 	"github.com/kiali/swscore/models"
 )
@@ -19,33 +18,13 @@ type serviceSupplier func(string, string) (*v1.ServiceSpec, error)
 // GetGrafanaInfo provides the Grafana URL and other info, first by checking if a config exists
 // then (if not) by inspecting the Kubernetes Grafana service in namespace istio-system
 func GetGrafanaInfo(w http.ResponseWriter, r *http.Request) {
-	info, code, err := getGrafanaInfo(getOpenshiftRouteURL, getGrafanaService)
+	info, code, err := getGrafanaInfo(getOpenshiftRouteURL, getService)
 	if err != nil {
 		log.Error(err)
 		RespondWithError(w, code, err.Error())
 		return
 	}
 	RespondWithJSON(w, code, info)
-}
-
-func getOpenshiftRouteURL(namespace string, name string) (string, error) {
-	client, err := kubernetes.NewOSRouteClient()
-	if err != nil {
-		return "", err
-	}
-	return client.GetRoute(namespace, name)
-}
-
-func getGrafanaService(namespace string, service string) (*v1.ServiceSpec, error) {
-	client, err := kubernetes.NewClient()
-	if err != nil {
-		return nil, err
-	}
-	details, err := client.GetServiceDetails(namespace, service)
-	if err != nil {
-		return nil, err
-	}
-	return &details.Service.Spec, nil
 }
 
 // getGrafanaInfo returns the Grafana URL and other info, the HTTP status code (int) and eventually an error

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -24,9 +24,6 @@ func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
 // getJaegerInfo returns the Jaeger URL, the HTTP status code (int) and eventually an error
 func getJaegerInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.JaegerInfo, int, error) {
 	jaegerConfig := config.Get().Jaeger
-	if !jaegerConfig.DisplayLink {
-		return nil, http.StatusNoContent, nil
-	}
 	jaegerInfo := models.JaegerInfo{
 		URL: jaegerConfig.URL}
 	if jaegerInfo.URL != "" {

--- a/handlers/jaeger.go
+++ b/handlers/jaeger.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"github.com/kiali/swscore/config"
+	"github.com/kiali/swscore/log"
+	"github.com/kiali/swscore/models"
+	"net/http"
+)
+
+// GetjaegerInfo provides the jaeger URLo, first by checking if a config exists
+// then (if not) by inspecting the Kubernetes Jaeger service in namespace istio-system
+func GetJaegerInfo(w http.ResponseWriter, r *http.Request) {
+	info, code, err := getJaegerInfo(getOpenshiftRouteURL, getService)
+	if err != nil {
+		log.Error(err)
+		RespondWithError(w, code, err.Error())
+		return
+	}
+	RespondWithJSON(w, code, info)
+}
+
+// getJaegerInfo returns the Jaeger URL, the HTTP status code (int) and eventually an error
+func getJaegerInfo(osRouteSupplier osRouteSupplier, serviceSupplier serviceSupplier) (*models.JaegerInfo, int, error) {
+	jaegerConfig := config.Get().Jaeger
+	if !jaegerConfig.DisplayLink {
+		return nil, http.StatusNoContent, nil
+	}
+	jaegerInfo := models.JaegerInfo{
+		URL: jaegerConfig.URL}
+	if jaegerInfo.URL != "" {
+		return &jaegerInfo, http.StatusOK, nil
+	}
+
+	url, err := osRouteSupplier(jaegerConfig.ServiceNamespace, jaegerConfig.Service)
+	if err == nil {
+		jaegerInfo.URL = url
+		return &jaegerInfo, http.StatusOK, nil
+	}
+	// Else on error, silently continue. Might not be running on OpenShift.
+
+	spec, err := serviceSupplier(jaegerConfig.ServiceNamespace, jaegerConfig.Service)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	if len(spec.ExternalIPs) == 0 {
+		return nil, http.StatusNotFound, errors.New("Unable to find Jaeger URL: no route defined. ExternalIPs not defined on service 'jaeger'")
+	}
+	var port int32
+	port = 80
+
+	if len(spec.ExternalIPs) > 1 {
+		log.Warning("Several IPs found for service 'jaeger', only the first will be used")
+	}
+	if len(spec.Ports) > 0 {
+		port = spec.Ports[0].Port
+		if len(spec.Ports) > 1 {
+			log.Warning("Several ports found for service 'jaeger', only the first will be used")
+		}
+	}
+
+	// detect https?
+	jaegerInfo.URL = fmt.Sprintf("http://%s:%d", spec.ExternalIPs[0], port)
+	return &jaegerInfo, http.StatusOK, nil
+}

--- a/handlers/jaeger_test.go
+++ b/handlers/jaeger_test.go
@@ -10,23 +10,6 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func TestGetJaegerInfoDisabled(t *testing.T) {
-	conf := config.NewConfig()
-	conf.Jaeger.DisplayLink = false
-	config.Set(conf)
-	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
-		return "http://fromopenshift", nil
-	}, func(_, _ string) (*v1.ServiceSpec, error) {
-		return &v1.ServiceSpec{
-			ClusterIP: "fromservice",
-			Ports: []v1.ServicePort{
-				v1.ServicePort{Port: 3000}}}, nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusNoContent, code)
-	assert.Nil(t, info)
-}
-
 func TestGetJaegerInfoFromOpenshift(t *testing.T) {
 	conf := config.NewConfig()
 	config.Set(conf)

--- a/handlers/jaeger_test.go
+++ b/handlers/jaeger_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/kiali/swscore/config"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+)
+
+func TestGetJaegerInfoDisabled(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Jaeger.DisplayLink = false
+	config.Set(conf)
+	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "http://fromopenshift", nil
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "fromservice",
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Nil(t, info)
+}
+
+func TestGetJaegerInfoFromOpenshift(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "http://fromopenshift", nil
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ClusterIP: "fromservice",
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://fromopenshift", info.URL)
+}
+
+func TestGetJaegerInfoFromService(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "", errors.New("")
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ExternalIPs: []string{"fromservice"},
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://fromservice:3000", info.URL)
+}
+
+func TestGetJaegerInfoFromConfig(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Jaeger.URL = "http://fromconfig:3001"
+	config.Set(conf)
+	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "http://fromopenshift", nil
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ExternalIPs: []string{"fromservice"},
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://fromconfig:3001", info.URL)
+}
+
+func TestGetJaegerInfoNoPort(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	info, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "", errors.New("")
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ExternalIPs: []string{"10.0.0.1"},
+			Ports:       []v1.ServicePort{}}, nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "http://10.0.0.1:80", info.URL)
+}
+
+func TestGetJaegerInfoNoExternalIP(t *testing.T) {
+	conf := config.NewConfig()
+	config.Set(conf)
+	_, code, err := getJaegerInfo(func(_, _ string) (string, error) {
+		return "", errors.New("")
+	}, func(_, _ string) (*v1.ServiceSpec, error) {
+		return &v1.ServiceSpec{
+			ExternalIPs: []string{},
+			Ports: []v1.ServicePort{
+				v1.ServicePort{Port: 3000}}}, nil
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"github.com/kiali/swscore/kubernetes"
+	"k8s.io/api/core/v1"
+)
+
+func getOpenshiftRouteURL(namespace string, name string) (string, error) {
+	client, err := kubernetes.NewOSRouteClient()
+	if err != nil {
+		return "", err
+	}
+	return client.GetRoute(namespace, name)
+}
+
+func getService(namespace string, service string) (*v1.ServiceSpec, error) {
+	client, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, err
+	}
+	details, err := client.GetServiceDetails(namespace, service)
+	if err != nil {
+		return nil, err
+	}
+	return &details.Service.Spec, nil
+}

--- a/models/jaeger_info.go
+++ b/models/jaeger_info.go
@@ -1,0 +1,6 @@
+package models
+
+// JaegerInfo provides information to access Jaeger UI
+type JaegerInfo struct {
+	URL string `json:"url"`
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -124,6 +124,12 @@ func NewRoutes() (r *Routes) {
 			"/api/grafana",
 			handlers.GetGrafanaInfo,
 		},
+		{
+			"JaegerURL",
+			"GET",
+			"/api/jaeger",
+			handlers.GetJaegerInfo,
+		},
 	}
 
 	return


### PR DESCRIPTION
Provide the url for jaeger

![jaeger_url](https://user-images.githubusercontent.com/3019213/37783934-f7e24cd4-2df6-11e8-885a-ccdb42c723fb.png)

@jotak I moved some methods of Grafana (Get service...) to utils because I need them to so please review this because is so similar to your code.