### PR TITLE
KIALI-407 use duration terminology for graph api/impl

### DIFF
--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -28,7 +28,7 @@ type Options struct {
 	Vendor    string
 	Metric    string
 	Offset    time.Duration
-	Interval  time.Duration
+	Duration  time.Duration
 	VendorOptions
 }
 
@@ -45,7 +45,7 @@ func NewOptions(r *http.Request) Options {
 	colorNormal := params.Get("colorNormal")
 	colorWarn := params.Get("colorWarn")
 	groupByVersion, groupByVersionErr := strconv.ParseBool(params.Get("groupByVersion"))
-	interval, intervalErr := time.ParseDuration(params.Get("interval"))
+	duration, durationErr := time.ParseDuration(params.Get("duration"))
 	metric := params.Get("metric")
 	offset, offsetErr := time.ParseDuration(params.Get("offset"))
 	vendor := params.Get("vendor")
@@ -67,8 +67,8 @@ func NewOptions(r *http.Request) Options {
 	if groupByVersionErr != nil {
 		groupByVersion = true
 	}
-	if intervalErr != nil {
-		interval, _ = time.ParseDuration("30s")
+	if durationErr != nil {
+		duration, _ = time.ParseDuration("10m")
 	}
 	if "" == metric {
 		metric = "istio_request_count"
@@ -90,7 +90,7 @@ func NewOptions(r *http.Request) Options {
 		Namespace: namespace,
 		Service:   service,
 		Vendor:    vendor,
-		Interval:  interval,
+		Duration:  duration,
 		Metric:    metric,
 		Offset:    offset,
 		VendorOptions: VendorOptions{

--- a/handlers/graph_test.go
+++ b/handlers/graph_test.go
@@ -47,7 +47,7 @@ func mockQuery(api *prometheustest.PromAPIMock, query string, ret *model.Vector)
 }
 
 func TestNamespaceGraph(t *testing.T) {
-	q0 := "sum(rate(istio_request_count{source_service!~\".*\\\\.istio-system\\\\..*\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (source_service)"
+	q0 := "sum(rate(istio_request_count{source_service!~\".*\\\\.istio-system\\\\..*\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_service)"
 	q0m0 := model.Metric{
 		"source_service": "unknown"}
 	q0m1 := model.Metric{
@@ -60,7 +60,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q0m1,
 			Value:  0}}
 
-	q1 := "sum(rate(istio_request_count{source_service=\"ingress.istio-system.svc.cluster.local\",source_version=\"unknown\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q1 := "sum(rate(istio_request_count{source_service=\"ingress.istio-system.svc.cluster.local\",source_version=\"unknown\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q1m0 := model.Metric{
 		"destination_service": "productpage.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -70,7 +70,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q1m0,
 			Value:  100}}
 
-	q2 := "sum(rate(istio_request_count{source_service=\"unknown\",source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q2 := "sum(rate(istio_request_count{source_service=\"unknown\",source_version=\"unknown\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q2m0 := model.Metric{
 		"destination_service": "productpage.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -80,7 +80,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q2m0,
 			Value:  50}}
 
-	q3 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q3 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q3m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -140,10 +140,10 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q3m7,
 			Value:  20}}
 
-	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	v4 := model.Vector{}
 
-	q5 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q5 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q5m0 := model.Metric{
 		"destination_service": "ratings.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -160,7 +160,7 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q5m1,
 			Value:  20}}
 
-	q6 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q6 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q6m0 := model.Metric{
 		"destination_service": "ratings.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -177,10 +177,10 @@ func TestNamespaceGraph(t *testing.T) {
 			Metric: q6m1,
 			Value:  20}}
 
-	q7 := "sum(rate(istio_request_count{source_service=\"details.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q7 := "sum(rate(istio_request_count{source_service=\"details.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	v7 := model.Vector{}
 
-	q8 := "sum(rate(istio_request_count{source_service=\"ratings.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q8 := "sum(rate(istio_request_count{source_service=\"ratings.istio-system.svc.cluster.local\",source_version=\"v1\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	v8 := model.Vector{}
 
 	client, api, err := setupMocked()
@@ -226,7 +226,7 @@ func TestNamespaceGraph(t *testing.T) {
 }
 
 func TestServiceGraph(t *testing.T) {
-	q0 := "sum(rate(istio_request_count{destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (source_service, source_version)"
+	q0 := "sum(rate(istio_request_count{destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (source_service, source_version)"
 	q0m0 := model.Metric{
 		"source_service": "productpage.istio-system.svc.cluster.local",
 		"source_version": "v1"}
@@ -247,7 +247,7 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q0m2,
 			Value:  20}}
 
-	q1 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q1 := "sum(rate(istio_request_count{source_service=\"productpage.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\"reviews\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q1m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v1",
@@ -271,10 +271,10 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q1m2,
 			Value:  20}}
 
-	q2 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q2 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v1\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	v2 := model.Vector{}
 
-	q3 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q3 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v2\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q3m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v2",
@@ -291,7 +291,7 @@ func TestServiceGraph(t *testing.T) {
 			Metric: q3m1,
 			Value:  20}}
 
-	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [30s])) by (destination_service,destination_version,response_code)"
+	q4 := "sum(rate(istio_request_count{source_service=\"reviews.istio-system.svc.cluster.local\",source_version=\"v3\",destination_service=~\".*\\\\.istio-system\\\\..*\",response_code=~\"[2345][0-9][0-9]\"} [600s])) by (destination_service,destination_version,response_code)"
 	q4m0 := model.Metric{
 		"destination_service": "reviews.istio-system.svc.cluster.local",
 		"destination_version": "v3",


### PR DESCRIPTION
- change from confusing 'interval' to correct and consistent 'duration'
  - also change to 10m default duration from 30s to generate a graph based
    on greater request data.